### PR TITLE
Check if wp_referer() exists.

### DIFF
--- a/public/public.php
+++ b/public/public.php
@@ -380,7 +380,8 @@ class Mihdan_NoExternalLinks_Public {
 
         // Checking for spammer attack, redirect should happen from your own website.
         if ( $this->options->check_referrer ) {
-            if ( stripos( wp_get_referer(), $this->data->site ) !== 0 ) {
+			$referer = wp_get_referer();
+            if ( $referer && stripos( $referer, $this->data->site ) !== 0 ) {
                 $this->show_referrer_warning();
             }
         }


### PR DESCRIPTION
Check if wp_referer() exists to work properly with rel="noreferrer" links.

Когда пользователь создаёт при редактировании поста ссылку "Open in New Tab", WordPress автоматически ей присваивает атрибут `rel="noreferrer noopener"`. Как результат, такая ссылка не проходит проверку, потому что `wp_referer()` при переходе по такой ссылке равен `false`. Плагин выдаёт предупреждение о переходе из небезопасного источника и осуществляет переадресацию на главную страницу.

Исправление игнорирует проверку для ссылок с noreferrer.